### PR TITLE
Imu data access

### DIFF
--- a/Amfitrack.cpp
+++ b/Amfitrack.cpp
@@ -136,6 +136,9 @@ void AMFITRACK::setDeviceName(uint8_t DeviceID, char* name, uint8_t length)
 {
     // Check for valid device ID and name length
     if (length >= MAX_NAME_LENGTH) return;
+#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutName);
+#endif // USE_THREAD_BASED
     for (uint8_t i = 0; i < length; i++)
     {
         Name[DeviceID][i] = name[i];
@@ -166,6 +169,9 @@ void AMFITRACK::checkDeviceDisconnected(uint8_t DeviceID)
 
     if (difftime(CurrentTime, DeviceLastTimeSeen[DeviceID]) > 5.0)
     {
+		#ifdef USE_THREAD_BASED
+		const std::lock_guard<std::mutex> lock(mutDeviceActive);
+		#endif // USE_THREAD_BASED
         DeviceActive[DeviceID] = false;
         std::cout << "Device " << std::dec << static_cast<unsigned>(DeviceID) << " disconnected" << std::endl;
     }
@@ -175,6 +181,9 @@ void AMFITRACK::checkDeviceDisconnected(uint8_t DeviceID)
 void AMFITRACK::setDeviceActive(uint8_t DeviceID)
 {
 #ifdef USE_ACTIVE_DEVICE_HANDLING
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutDeviceActive);
+	#endif // USE_THREAD_BASED
     if (!DeviceActive[DeviceID]) std::cout << "Device " << std::dec << static_cast<unsigned>(DeviceID) << " connected" << std::endl;
     DeviceActive[DeviceID] = true;
     DeviceLastTimeSeen[DeviceID] = time(0);
@@ -186,11 +195,17 @@ void AMFITRACK::setDeviceActive(uint8_t DeviceID)
 
 bool AMFITRACK::getDeviceActive(uint8_t DeviceID)
 {
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutDeviceActive);
+	#endif // USE_THREAD_BASED
     return DeviceActive[DeviceID];
 }
 
 void AMFITRACK::setDevicePose(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Pose_t Pose)
 {
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutPosition);
+	#endif // USE_THREAD_BASED
     memcpy(&Position[DeviceID], &Pose, sizeof(lib_AmfiProt_Amfitrack_Pose_t));
 #ifdef AMFITRACK_DEBUG_INFO
     std::cout << "Pose set!" << std::endl;
@@ -202,17 +217,26 @@ void AMFITRACK::setDevicePose(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Pose_t Po
 void AMFITRACK::getDevicePose(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Pose_t* Pose)
 {
     if (!getDeviceActive(DeviceID)) return;
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutPosition);
+	#endif // USE_THREAD_BASED
     memcpy(Pose, &Position[DeviceID], sizeof(lib_AmfiProt_Amfitrack_Pose_t));
 }
 
 void AMFITRACK::setSensorMeasurements(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Sensor_Measurement_t SensorMeasurement)
 {
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutSensorMeasurements);
+	#endif // USE_THREAD_BASED
     memcpy(&SensorMeasurements[DeviceID], &SensorMeasurement, sizeof(lib_AmfiProt_Amfitrack_Sensor_Measurement_t));
 }
 
 void AMFITRACK::getSensorMeasurements(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Sensor_Measurement_t* SensorMeasurement)
 {
     if (!getDeviceActive(DeviceID)) return;
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutSensorMeasurements);
+	#endif // USE_THREAD_BASED
     memcpy(SensorMeasurement, &SensorMeasurements[DeviceID], sizeof(lib_AmfiProt_Amfitrack_Sensor_Measurement_t));
 }
 
@@ -489,12 +513,18 @@ std::chrono::steady_clock::time_point getTimestampMicroseconds()
 
 void AMFITRACK::setSensorTimestamp(uint8_t DeviceID, std::chrono::steady_clock::time_point time_stamp)
 {
+#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutSensorTimestamps);
+#endif // USE_THREAD_BASED
     memcpy(&SensorTimestamps[DeviceID], &time_stamp, sizeof(std::chrono::steady_clock::time_point));
 }
 
 void AMFITRACK::getSensorTimestamp(uint8_t DeviceID, std::chrono::steady_clock::time_point* time_stamp)
 {
     if (!getDeviceActive(DeviceID)) return;
+#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutSensorTimestamps);
+#endif // USE_THREAD_BASED
     memcpy(time_stamp, &SensorTimestamps[DeviceID], sizeof(std::chrono::steady_clock::time_point));
 }
 

--- a/Amfitrack.cpp
+++ b/Amfitrack.cpp
@@ -223,6 +223,23 @@ void AMFITRACK::getDevicePose(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Pose_t* P
     memcpy(Pose, &Position[DeviceID], sizeof(lib_AmfiProt_Amfitrack_Pose_t));
 }
 
+void AMFITRACK::setDeviceIMU(uint8_t DeviceID, lib_AmfiProt_Amfitrack_IMU_t imuData)
+{
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutIMU);
+	#endif // USE_THREAD_BASED
+    memcpy(&IMUData[DeviceID], &imuData, sizeof(lib_AmfiProt_Amfitrack_IMU_t));
+}
+
+void AMFITRACK::getDeviceIMU(uint8_t DeviceID, lib_AmfiProt_Amfitrack_IMU_t* imuData)
+{
+    if (!getDeviceActive(DeviceID)) return;
+	#ifdef USE_THREAD_BASED
+	const std::lock_guard<std::mutex> lock(mutSensorMeasurements);
+	#endif // USE_THREAD_BASED
+    memcpy(imuData, &IMUData[DeviceID], sizeof(lib_AmfiProt_Amfitrack_IMU_t));
+}
+
 void AMFITRACK::setSensorMeasurements(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Sensor_Measurement_t SensorMeasurement)
 {
 	#ifdef USE_THREAD_BASED
@@ -260,6 +277,9 @@ void AmfiProt_API::lib_AmfiProt_Amfitrack_handle_SensorMeasurement(void* handle,
     lib_AmfiProt_Amfitrack_Pose_t tempPose;
     lib_AmfiProt_Amfitrack_decode_pose_i24(&SensorMeasurement.pose, &tempPose);
     AMFITRACK.setDevicePose(frame->header.source, tempPose);
+    lib_AmfiProt_Amfitrack_IMU_t tempIMU;
+    lib_AmfiProt_Amfitrack_decodeIMU_i16(&SensorMeasurement.imu_data, &tempIMU);
+    AMFITRACK.setDeviceIMU(frame->header.source, tempIMU);
     AMFITRACK.setSensorMeasurements(frame->header.source, SensorMeasurement);
     AMFITRACK.setDeviceActive(frame->header.source);
 }

--- a/Amfitrack.hpp
+++ b/Amfitrack.hpp
@@ -24,6 +24,9 @@
 #include <stdbool.h>
 #include "src/project_conf.h"
 #include "lib/amfiprotapi/lib_AmfiProt_API.hpp"
+#ifdef USE_THREAD_BASED
+#include <mutex>
+#endif // USE_THREAD_BASED
 
 
 //-----------------------------------------------------------------------------
@@ -86,13 +89,31 @@ public:
 #endif
 
 private:
+#ifdef USE_THREAD_BASED
+    std::mutex mutName; // Protects array of names
+#endif // USE_THREAD_BASED
 	char Name[MAX_NUMBER_OF_DEVICES][MAX_NAME_LENGTH]; // Array of character arrays to store device names
+
+#ifdef USE_THREAD_BASED
+	std::mutex mutDeviceActive; // Protects array of DeviceActive bools
+#endif // USE_THREAD_BASED
 	bool DeviceActive[MAX_NUMBER_OF_DEVICES];
+
 #ifdef USE_ACTIVE_DEVICE_HANDLING
+#ifdef USE_THREAD_BASED
+    std::mutex mutDeviceLastSeen; // Protects array of last seen times
+#endif // USE_THREAD_BASED
 	time_t DeviceLastTimeSeen[MAX_NUMBER_OF_DEVICES];
 #endif
 
+#ifdef USE_THREAD_BASED
+	std::mutex mutPosition; // Protects array of position poses
+#endif // USE_THREAD_BASED
 	lib_AmfiProt_Amfitrack_Pose_t Position[MAX_NUMBER_OF_DEVICES];
+
+#ifdef USE_THREAD_BASED
+	std::mutex mutSensorMeasurements; // Protects array of sensor measurement structs
+#endif // USE_THREAD_BASED
 	lib_AmfiProt_Amfitrack_Sensor_Measurement_t SensorMeasurements[MAX_NUMBER_OF_DEVICES];
 	
 	static void background_amfitrack_task(AMFITRACK*);
@@ -101,6 +122,9 @@ private:
 	AMFITRACK();
 	~AMFITRACK();
 #if defined(_WIN32) || defined(__linux__) || defined(__APPLE__)
+#ifdef USE_THREAD_BASED
+    std::mutex mutSensorTimestamps; // Protects array of sensor timestamps
+#endif // USE_THREAD_BASED
 	std::chrono::steady_clock::time_point SensorTimestamps[MAX_NUMBER_OF_DEVICES];
 #endif
 };

--- a/Amfitrack.hpp
+++ b/Amfitrack.hpp
@@ -78,6 +78,9 @@ public:
 	/* Get the pose for a specific device */
 	void getDevicePose(uint8_t DeviceID, lib_AmfiProt_Amfitrack_Pose_t* Pose);
 
+	void setDeviceIMU(uint8_t DeviceID, lib_AmfiProt_Amfitrack_IMU_t imuData);
+	void getDeviceIMU(uint8_t DeviceID, lib_AmfiProt_Amfitrack_IMU_t* imuData);
+
 	void setSensorMeasurements(uint8_t DeviceID,lib_AmfiProt_Amfitrack_Sensor_Measurement_t SensorMeasurement);
 
 	void getSensorMeasurements(uint8_t DeviceID,lib_AmfiProt_Amfitrack_Sensor_Measurement_t* SensorMeasurement);
@@ -110,6 +113,12 @@ private:
 	std::mutex mutPosition; // Protects array of position poses
 #endif // USE_THREAD_BASED
 	lib_AmfiProt_Amfitrack_Pose_t Position[MAX_NUMBER_OF_DEVICES];
+
+#ifdef USE_THREAD_BASED
+	std::mutex mutIMU; // Protects array of position poses
+#endif // USE_THREAD_BASED
+	lib_AmfiProt_Amfitrack_IMU_t IMUData[MAX_NUMBER_OF_DEVICES];
+
 
 #ifdef USE_THREAD_BASED
 	std::mutex mutSensorMeasurements; // Protects array of sensor measurement structs


### PR DESCRIPTION
This adds access functions to expose the IMU data to any consumer of the Amfitrack_API class. It depends on the mutex-locking pull request I already submitted, because it contains mutexes in the same pattern as that branch.