### PR TITLE
Fix unconditionally treating every device as sensor

### DIFF
--- a/src/Amfitrack_Devices.cpp
+++ b/src/Amfitrack_Devices.cpp
@@ -607,8 +607,6 @@ bool AMFITRACK_Devices::set(uint8_t device_id, deviceType_t type, IMU_t const &i
 	}
 
 	update_last_seen(device_id, newType);
-
-	update_last_seen(device_id, deviceType_t::Sensor);
 	return true;
 }
 


### PR DESCRIPTION
The function update_last_seen was called twice, once correctly with the inferred type and once just with type sensor.
The fix is to remove the second call, keeping the one with the inferred type.