### PR TITLE
Fix config discovery failing for sources

### DIFF
--- a/src/Amfitrack_config.cpp
+++ b/src/Amfitrack_config.cpp
@@ -13,6 +13,7 @@
 
 #include "Amfitrack_Devices.h"
 #include "Amfitrack_Sensor.h"
+#include "Amfitrack_Source.h"
 #include "lib_AmfiProt_API.hpp"
 #include "lib_log.h"
 #include "lib_time.h"
@@ -136,13 +137,22 @@ void sanitize(DeviceConfig_t &config)
 DeviceConfig_t load_config(uint8_t device_id)
 {
 	DeviceConfig_t config = {};
-	AMFITRACK_Sensor sensor;
+	AMFITRACK_Devices &devices = AMFITRACK_Devices::getInstance();
 
-	if (AMFITRACK_Devices::getInstance().get_sensor_by_id(device_id, &sensor))
+	AMFITRACK_Sensor sensor;
+	AMFITRACK_Source source;
+
+	if (devices.get_sensor_by_id(device_id, &sensor))
 	{
 		config = sensor.config;
 		sanitize(config);
-		LOG_D("load_config: device_id=%u, categoryCount=%u", device_id, config.categoryCount);
+		LOG_D("load_config: device_id=%u (sensor), categoryCount=%u", device_id, config.categoryCount);
+	}
+	else if (devices.get_source_by_id(device_id, &source))
+	{
+		config = source.config;
+		sanitize(config);
+		LOG_D("load_config: device_id=%u (source), categoryCount=%u", device_id, config.categoryCount);
 	}
 	else
 	{

--- a/src/Amfitrack_task.cpp
+++ b/src/Amfitrack_task.cpp
@@ -70,39 +70,24 @@ void amfitrack_task::getMissingInfo()
 	if (lastGetMissingInfoTimeMs == 0 ||
 		(now - lastGetMissingInfoTimeMs) >= kGetMissingInfoIntervalMs)
 	{
+		// Sensors and sources expose the same version/name fields, so both kinds
+		// are queried for whatever info is currently missing.
 		for (uint8_t i = 0; i < AMFITRACK_DEVICE_COUNT; i++)
 		{
 			AMFITRACK_Sensor sensor;
 			AMFITRACK_Devices::getInstance().get_sensor_by_id(i, &sensor);
-			if (!sensor.active)
-				continue;
-
-			switch (missingInfo)
+			if (sensor.active)
 			{
-				case amfitrack_task::missingInfo_t::missingInfo_FW:
-					if (sensor.FW_Version.Major == 0)
-					{
-						getVersion(i, AMFITRACK_FW_VERSION_ID);
-					}
-					break;
-				case amfitrack_task::missingInfo_t::missingInfo_RF:
-					if (sensor.RF_Version.Major == 0)
-					{
-						getVersion(i, AMFITRACK_RF_VERSION_ID);
-					}
-					break;
-				case amfitrack_task::missingInfo_t::missingInfo_HW:
-					if (sensor.HW_Version.Generation == 0)
-					{
-						getVersion(i, AMFITRACK_HW_VERSION_ID);
-					}
-					break;
-				case amfitrack_task::missingInfo_t::missingInfo_Name:
-					if (sensor.name[0] == 0x00)
-					{
-						getName(i);
-					}
-					break;
+				requestMissingInfo(i, sensor.FW_Version, sensor.RF_Version,
+								   sensor.HW_Version, sensor.name);
+			}
+
+			AMFITRACK_Source source;
+			AMFITRACK_Devices::getInstance().get_source_by_id(i, &source);
+			if (source.active)
+			{
+				requestMissingInfo(i, source.FW_Version, source.RF_Version,
+								   source.HW_Version, source.name);
 			}
 		}
 		switch (missingInfo)
@@ -121,6 +106,38 @@ void amfitrack_task::getMissingInfo()
 				break;
 		}
 		lastGetMissingInfoTimeMs = now;
+	}
+}
+
+void amfitrack_task::requestMissingInfo(uint8_t deviceID, const FW_t &fw, const RF_t &rf,
+										const HW_t &hw, const char *name)
+{
+	switch (missingInfo)
+	{
+		case amfitrack_task::missingInfo_t::missingInfo_FW:
+			if (fw.Major == 0)
+			{
+				getVersion(deviceID, AMFITRACK_FW_VERSION_ID);
+			}
+			break;
+		case amfitrack_task::missingInfo_t::missingInfo_RF:
+			if (rf.Major == 0)
+			{
+				getVersion(deviceID, AMFITRACK_RF_VERSION_ID);
+			}
+			break;
+		case amfitrack_task::missingInfo_t::missingInfo_HW:
+			if (hw.Generation == 0)
+			{
+				getVersion(deviceID, AMFITRACK_HW_VERSION_ID);
+			}
+			break;
+		case amfitrack_task::missingInfo_t::missingInfo_Name:
+			if (name[0] == 0x00)
+			{
+				getName(deviceID);
+			}
+			break;
 	}
 }
 

--- a/src/Amfitrack_task.h
+++ b/src/Amfitrack_task.h
@@ -12,6 +12,7 @@
 // Section: Includes
 //-----------------------------------------------------------------------------
 #include <cstdint>
+#include "AmfitrackDeviceTypes.h"
 //-----------------------------------------------------------------------------
 // Section: Define
 //-----------------------------------------------------------------------------
@@ -52,6 +53,8 @@ class amfitrack_task
 	static void getVersion(uint8_t deviceID, uint8_t _version);
 	static void getName(uint8_t deviceID);
 	static void getMissingInfo();
+	static void requestMissingInfo(uint8_t deviceID, const FW_t &fw, const RF_t &rf,
+								   const HW_t &hw, const char *name);
 	static missingInfo_t missingInfo;
 };
 


### PR DESCRIPTION
Load config currently fails for sources, since it only checks for sensors. This fix adds a second check for sources. I assume there might be a similar fix necessary for hubs but since we are not using them, I have not spent time investigating.