### PR TITLE
Fix bool config values being treated as void and getting lost

### DIFF
--- a/lib/amfiprotapi/lib_AmfiProt_API.hpp
+++ b/lib/amfiprotapi/lib_AmfiProt_API.hpp
@@ -141,7 +141,7 @@ class AmfiProt_API : public lib_AmfiProt, public lib_AmfiProt_AmfiTrack
 
 	void process_incoming_queue(void);
 
-	uint8_t packetNumber[255];
+	uint8_t packetNumber[256];
 
 	uint8_t _retransmitCount;
 	bool _lastPackageNumberError;

--- a/lib/lib_generic_parameter/lib_Generic_Parameter.cpp
+++ b/lib/lib_generic_parameter/lib_Generic_Parameter.cpp
@@ -8,9 +8,9 @@ static uint8_t lib_Generic_Parameter_ValueSizeWithoutType(
 {
 	switch (value.type)
 	{
+		// void is carried as a bool: the device firmware encodes void as a single bool byte
+		// we have to reserve, compare and serialize that byte just like an explicit bool
 		case lib_Generic_Parameter_Type_void:
-			return sizeof(value.b); // Legacy compatibility
-
 		case lib_Generic_Parameter_Type_bool:
 		case lib_Generic_Parameter_Type_ProcedureCall:
 			return sizeof(value.b);
@@ -72,9 +72,9 @@ bool lib_Generic_Parameter_ValueIsEqual(
 
 	switch (v1.type)
 	{
+		// void is compared as a bool (see size function): the trailing byte is
+		// significant, so do not treat all void values as equal.
 		case lib_Generic_Parameter_Type_void:
-			return true;
-
 		case lib_Generic_Parameter_Type_bool:
 		case lib_Generic_Parameter_Type_ProcedureCall:
 			return v1.b == v2.b;
@@ -163,12 +163,10 @@ uint8_t lib_Generic_Parameter_SerializeValueAndType(
 
 	switch (value.type)
 	{
+		// void is serialized as a bool: size function reserves a byte for it, so
+		// we must actually copy value.b (the old code reported the size but left
+		// the byte uninitialized).
 		case lib_Generic_Parameter_Type_void:
-			// Legacy compatibility:
-			// old implementation reported type + bool size for void,
-			// but did not copy a value.
-			break;
-
 		case lib_Generic_Parameter_Type_bool:
 		case lib_Generic_Parameter_Type_ProcedureCall:
 			std::memcpy(dest, &value.b, valueSize);

--- a/src/Amfitrack_config.cpp
+++ b/src/Amfitrack_config.cpp
@@ -857,7 +857,8 @@ static void log_parameter_value(const lib_Generic_Parameter_Value &value)
 	switch (static_cast<lib_Generic_Parameter_Type_t>(value.type))
 	{
 		case lib_Generic_Parameter_Type_void:
-			LOG_I("        value=(void)");
+			// void carries a bool byte (see lib_Generic_Parameter): show it.
+			LOG_I("        value=(void/bool)%s", value.b ? "true" : "false");
 			break;
 		case lib_Generic_Parameter_Type_bool:
 			LOG_I("        value=(bool)%s", value.b ? "true" : "false");

--- a/src/Amfitrack_config.cpp
+++ b/src/Amfitrack_config.cpp
@@ -608,6 +608,17 @@ bool AMFITRACK_Config::set(uint8_t device_id, lib_AmfiProt_ConfigValueUID_t cons
 
 bool AMFITRACK_Config::request_current()
 {
+	// abort discovery if a device disconnects while config is being discovered - previously it would keep retrying forever
+	if (_state != CONFIG_DISCOVERY_IDLE && _state != CONFIG_DISCOVERY_DONE &&
+		!AMFITRACK_Devices::getInstance().is_device_active(_device_id))
+	{
+		LOG_W("request_current: device %u no longer active, aborting discovery (state=%d)",
+			  _device_id, (int)_state);
+		_state = CONFIG_DISCOVERY_IDLE;
+		set_waiting_for_reply(false);
+		return false;
+	}
+
 	if (_waiting_for_reply)
 	{
 		const uint32_t now = lib_time::get_time_ms();


### PR DESCRIPTION
The amfitrack firmware reports bool config values as lib_Generic_Parameter_Type_void aka type 0. These still carry the bool byte and function as a bool however. The API right now threw out the bool value and treated them as void.